### PR TITLE
util: use bcrypto rng over Math.random

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -15,6 +15,7 @@
 const assert = require('bsert');
 const IP = require('binet');
 const bio = require('bufio');
+const bcrypto = require('bcrypto');
 const {sizeName} = require('./encoding');
 const util = exports;
 const YEAR68 = (1 << 31) >>> 0;
@@ -553,7 +554,7 @@ util.hasAll = function hasAll(records, type) {
 
 util.random = function random(n) {
   assert(typeof n === 'number');
-  return Math.floor(Math.random() * n);
+  return bcrypto.random.randomRange(0, n);
 };
 
 util.randomItem = function randomItem(items) {
@@ -757,13 +758,13 @@ util.isIP = function isIP(host) {
 };
 
 util.id = function id() {
-  return (Math.random() * 0x10000) >>> 0;
+  return bcrypto.random.randomRange(0, 65536);
 };
 
 util.cookie = function cookie() {
   const buf = Buffer.allocUnsafe(8);
-  const hi = (Math.random() * 0x100000000) >>> 0;
-  const lo = (Math.random() * 0x100000000) >>> 0;
+  const hi = bcrypto.random.randomInt();
+  const lo = bcrypto.random.randomInt();
   bio.writeU32(buf, lo, 0);
   bio.writeU32(buf, hi, 4);
   return buf;
@@ -995,7 +996,7 @@ util.serializeTime = function serializeTime(t) {
  */
 
 function cmpRandom(a, b) {
-  return Math.random() > 0.5 ? 1 : -1;
+  return bcrypto.random.randomRange(0, 2) === 1 ? 1 : -1;
 }
 
 function unpad(str, start, end) {


### PR DESCRIPTION
This PR replaces calls to `Math.random` with randomness that comes from `bcrypto` in `lib/util`.