### PR TITLE
wire, schema: SUBNETOption compliant with RFC7871

### DIFF
--- a/lib/internal/schema.js
+++ b/lib/internal/schema.js
@@ -512,7 +512,7 @@ const SUBNETSchema = [
   ['family', U16],
   ['sourceNetmask', U8],
   ['sourceScope', U8],
-  ['address', INET]
+  ['address', HEXEND]
 ];
 
 const EXPIRESchema = [

--- a/lib/wire.js
+++ b/lib/wire.js
@@ -5759,44 +5759,29 @@ class SUBNETOption extends OptionData {
     this.family = 1;
     this.sourceNetmask = 0;
     this.sourceScope = 0;
-    this.address = '0.0.0.0';
-    this.data = DUMMY;
+    this.address = DUMMY;
   }
 
   get code() {
     return options.SUBNET;
   }
 
+  // SOURCE PREFIX-LENGTH represents a number of bits.
+  // The actual data must be padded to the end of the next octet.
+  getAddressSize() {
+    return Math.ceil(this.sourceNetmask / 8);
+  }
+
   getSize() {
-    switch (this.family) {
-      case 1:
-        return 4 + 4;
-      case 2:
-        return 4 + 16;
-      default:
-        return 4 + this.data.length;
-    }
+    return 4 + this.getAddressSize();
   }
 
   write(bw) {
+    assert(this.address.length === this.getAddressSize());
     bw.writeU16BE(this.family);
     bw.writeU8(this.sourceNetmask);
     bw.writeU8(this.sourceScope);
-
-    switch (this.family) {
-      case 1: {
-        writeIP(bw, this.address, 4);
-        break;
-      }
-      case 2: {
-        writeIP(bw, this.address, 16);
-        break;
-      }
-      default: {
-        bw.writeBytes(this.data);
-        break;
-      }
-    }
+    bw.writeBytes(this.address);
 
     return this;
   }
@@ -5805,18 +5790,7 @@ class SUBNETOption extends OptionData {
     this.family = br.readU16BE();
     this.sourceNetmask = br.readU8();
     this.sourceScope = br.readU8();
-
-    switch (this.family) {
-      case 1:
-        this.address = readIP(br, 4);
-        break;
-      case 2:
-        this.address = readIP(br, 16);
-        break;
-      default:
-        this.data = br.readBytes(br.left());
-        break;
-    }
+    this.address = br.readBytes(this.getAddressSize());
 
     return this;
   }


### PR DESCRIPTION
In specifying the wire format for the EDNS0 Subnet Option (see  RFC6891), the option contains an `ADDRESS` field, but it is not actually a complete address, since a bitmask is applied and the data is truncated.

From [RFC7871 "Client Subnet in DNS Queries":](https://tools.ietf.org/html/rfc7871#section-6)

```
ADDRESS, variable number of octets, contains either an IPv4 or
IPv6 address, depending on FAMILY, which MUST be truncated to the
number of bits indicated by the SOURCE PREFIX-LENGTH field,
padding with 0 bits to pad to the end of the last octet needed.
```

Experimentation reveals that indeed `dig` will truncate the address in the query itself. i.e. a query with `4.3.2.1/8` will only send a single byte in the `ADDRESS` field. However, `bns` expects 4 or 16 bytes for the `ADDRESS`, depending on the indicated `FAMILY`.

The bug can be triggered by making a DNS request with a subnet option:

This will throw a `bufio` "Out of bounds" error on a bns Authoritative Resolver:
```
dig @localhost -p 25350 google.com +subnet=4.3.2.1/5
```



The same query can be made against `8.8.8.8` to get a valid response. In fact, `8.8.8.8` supports EDNS subnet options, and different subnet IPs will fetch different `A` record results!

This PR changes the expected value of the `ADDRESS` field to a raw buffer, whose length is defined by the `SOURCE PREFIX-LENGTH` value in the query.