### PR TITLE
Constants: recognize ZSK as keyFlag

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -503,7 +503,8 @@ const keyFlags = {
   SEP: 1 << 0,
   // 1-6 reserved
   REVOKE: 1 << 7,
-  ZONE: 1 << 8
+  ZONE: 1 << 8,
+  ZSK: 1 << 8,
   // 9-15 reserved
 };
 


### PR DESCRIPTION
`keyFlags.ZSK` is used in the tests but not actually defined:

https://github.com/chjj/bns/blob/03b0ea5e7587774c0c3ad363f094a069acc1e60b/test/dnssec-test.js#L157

