### PR TITLE
api: require constants derived from system in nodejs dns module

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -20,6 +20,7 @@ const sshfp = require('./sshfp');
 const tlsa = require('./tlsa');
 const util = require('./util');
 const wire = require('./wire');
+const nodejsdns = require('dns');
 const {DNS_PORT} = constants;
 const {types, codes} = wire;
 
@@ -59,8 +60,8 @@ class API extends EventEmitter {
       return new API(create, options);
     };
 
-    this.V4MAPPED = 8;
-    this.ADDRCONFIG = 32;
+    this.V4MAPPED = nodejsdns.V4MAPPED;
+    this.ADDRCONFIG = nodejsdns.ADDRCONFIG;
 
     this.NODATA = 'ENODATA';
     this.FORMERR = 'EFORMERR';


### PR DESCRIPTION
Running the example from the [hdns README](https://github.com/handshake-org/hdns#usage-in-nodejs):

```js
const dns = require('hdns');
const http = require('http');

http.get({
  protocol: 'http:',
  hostname: 'google.com',
  lookup: dns.legacy
}, (res) => {
  res.setEncoding('utf8');
  res.on('data', (data) => {
    console.log(data);
  });
});
```

results in this error on OSX:
```
TypeError [ERR_INVALID_OPT_VALUE]: Invalid argument: "hints".
    at makeTypeError (/Users/matthewzipkin/Desktop/work/hdns/node_modules/bns/lib/api.js:854:15)
    at API.legacy (/Users/matthewzipkin/Desktop/work/hdns/node_modules/bns/lib/api.js:765:15)
    at net.js:1030:5
    at defaultTriggerAsyncIdScope (internal/async_hooks.js:301:12)
    at lookupAndConnect (net.js:1029:3)
    at Socket.connect (net.js:963:5)
    at Agent.connect [as createConnection] (net.js:172:17)
    at Agent.createSocket (_http_agent.js:234:26)
    at Agent.addRequest (_http_agent.js:193:10)
    at new ClientRequest (_http_client.js:276:16) {
  code: 'ERR_INVALID_OPT_VALUE',
  name: 'TypeError [ERR_INVALID_OPT_VALUE]'
```

I traced the error back the API in bns, which is used for the stubbed `lookup` function passed to the `http.get()` call.

The [`getaddrinfo` flags](https://nodejs.org/api/dns.html#dns_supported_getaddrinfo_flags) are not actually constants from nodejs -- they come from [the system nodejs was compiled on](https://linux.die.net/man/3/getaddrinfo).

For example:

### OSX
```
$ node
> require('dns').V4MAPPED;
2048
```


### Ubuntu
```
$ node
> require('dns').V4MAPPED;
8
```

I'm sure there's a better fix for this since the whole point is NOT using nodejs `dns` module, but I'm not sure a better way besides requiring the module just grab those constants.