### PR TITLE
Various updates to match authoritative behavior of BIND9

### DIFF
--- a/lib/zone.js
+++ b/lib/zone.js
@@ -145,12 +145,16 @@ class Zone {
     return map.rrs.has(type);
   }
 
-  glue(name, an) {
+  glue(name, an, type) {
     assert(util.isFQDN(name));
     assert(Array.isArray(an));
 
-    this.push(name, types.A, an);
-    this.push(name, types.AAAA, an);
+    if (!type) {
+      this.push(name, types.A, an);
+      this.push(name, types.AAAA, an);
+    } else {
+      this.push(name, type, an);
+    }
 
     return this;
   }
@@ -162,10 +166,10 @@ class Zone {
     for (const rr of an) {
       switch (rr.type) {
         case types.CNAME:
-          this.glue(rr.data.target, an);
+          this.glue(rr.data.target, an, type);
           break;
         case types.DNAME:
-          this.glue(rr.data.target, an);
+          this.glue(rr.data.target, an, type);
           break;
         case types.NS:
           this.glue(rr.data.ns, ar);

--- a/lib/zone.js
+++ b/lib/zone.js
@@ -561,7 +561,11 @@ function convert(name, rr) {
 
   rr = rr.clone();
 
-  y[0] = x[x.length - y.length];
+  // Replace '*' with prefix, may be multiple labels
+  y.shift();
+  let diff = x.length - y.length - 1;
+  for (; diff >= 0; diff--)
+    y.unshift(x[diff]);
 
   rr.name = `${y.join('.')}.`;
 

--- a/lib/zone.js
+++ b/lib/zone.js
@@ -145,9 +145,11 @@ class Zone {
     return map.rrs.has(type);
   }
 
-  glue(name, an, type) {
+  glue(name, an, type, ns) {
     assert(util.isFQDN(name));
     assert(Array.isArray(an));
+
+    const initial = an.length;
 
     if (!type) {
       this.push(name, types.A, an);
@@ -156,20 +158,29 @@ class Zone {
       this.push(name, type, an);
     }
 
+    const final = an.length;
+
+    // If the only answer we have is a CNAME with no "glue",
+    // include an SOA in the authority section, just like
+    // if we had no answer for a name we're authoritative over.
+    if (initial === final)
+      this.push(name, types.SOA, ns);
+
     return this;
   }
 
   find(name, type) {
     const an = this.get(name, type);
     const ar = [];
+    const ns = [];
 
     for (const rr of an) {
       switch (rr.type) {
         case types.CNAME:
-          this.glue(rr.data.target, an, type);
+          this.glue(rr.data.target, an, type, ns);
           break;
         case types.DNAME:
-          this.glue(rr.data.target, an, type);
+          this.glue(rr.data.target, an, type, ns);
           break;
         case types.NS:
           this.glue(rr.data.ns, ar);
@@ -186,7 +197,7 @@ class Zone {
       }
     }
 
-    return [an, ar];
+    return [an, ar, ns];
   }
 
   getHints() {
@@ -234,12 +245,17 @@ class Zone {
     assert(util.isFQDN(name));
     assert((type & 0xffff) === type);
 
-    const [an, ar] = this.find(name, type);
+    const labels = util.split(name);
+    const zone = util.from(name, labels, -this.count);
+    const authority = util.equal(zone, this.origin);
+
+    let [an, ar, ns] = this.find(name, type);
+    let glue;
 
     // Do we have an answer?
     if (an.length > 0) {
       // Are we authoritative for this name?
-      if (!this.has(name, types.SOA)) {
+      if (!authority) {
         // If we're not authoritative for this
         // name, this is probably a request
         // for a DS or NSEC record.
@@ -250,34 +266,17 @@ class Zone {
           return [[], an, ar, false, true];
         }
 
-        // Send the answer but do
-        // not set the `aa` bit.
         return [an, [], ar, false, true];
       }
 
       // We're authoritative. Send the
       // answer and set the `aa` bit.
-      return [an, [], ar, true, true];
-    }
-
-    const labels = util.split(name);
-
-    // Are they requesting a child of our
-    // origin? If not, handle the mishap
-    // gracefully.
-    if (this.origin !== '.') {
-      const zone = util.from(name, labels, -this.count);
-
-      // Refer them back to the root zone.
-      if (!util.equal(zone, this.origin)) {
-        const [ns, ar] = this.getHints();
-        return [[], ns, ar, false, true];
-      }
+      return [an, ns, ar, true, true];
     }
 
     // Couldn't find anything.
     // Serve an SoA (no data).
-    if (labels.length === this.count) {
+    if (authority) {
       const ns = this.get(this.origin, types.SOA);
       this.proveNoData(ns);
       return [[], ns, [], true, false];
@@ -288,7 +287,7 @@ class Zone {
     // might have a referral for.
     const index = this.count + 1;
     const child = util.from(name, labels, -index);
-    const [ns, glue] = this.find(child, types.NS);
+    [ns, glue] = this.find(child, types.NS);
 
     // Couldn't find any nameservers.
     // Serve an SoA (nxdomain).

--- a/lib/zone.js
+++ b/lib/zone.js
@@ -393,19 +393,39 @@ class RecordMap {
     assert((type & 0xffff) === type);
     assert(Array.isArray(an));
 
+    // If a name has a CNAME record, there should be no
+    // other records for that name in the zone.
+    // (RFC 1034 section 3.6.2, RFC 1912 section 2.4)
+    if (type !== types.CNAME) {
+      const rrs = this.rrs.get(types.CNAME);
+
+      if (rrs && rrs.length > 0) {
+        for (const rr of rrs)
+          an.push(convert(name, rr));
+
+        const sigs = this.sigs.get(types.CNAME);
+
+        if (sigs) {
+          for (const rr of sigs)
+            an.push(convert(name, rr));
+        }
+
+        return this;
+      }
+    }
+
     const rrs = this.rrs.get(type);
 
-    if (!rrs || rrs.length === 0)
-      return this;
-
-    for (const rr of rrs)
-      an.push(convert(name, rr));
-
-    const sigs = this.sigs.get(type);
-
-    if (sigs) {
-      for (const rr of sigs)
+    if (rrs && rrs.length > 0) {
+      for (const rr of rrs)
         an.push(convert(name, rr));
+
+      const sigs = this.sigs.get(type);
+
+      if (sigs) {
+        for (const rr of sigs)
+          an.push(convert(name, rr));
+      }
     }
 
     return this;

--- a/lib/zone.js
+++ b/lib/zone.js
@@ -121,8 +121,8 @@ class Zone {
 
     if (map)
       map.push(name, type, an);
-
-    this.wild.push(name, type, an);
+    else
+      this.wild.push(name, type, an);
 
     return this;
   }

--- a/lib/zone.js
+++ b/lib/zone.js
@@ -392,6 +392,40 @@ class RecordMap {
     return this;
   }
 
+  filterMatches(name, rrs) {
+    const ret = [];
+
+    for (const rr of rrs) {
+      if (!isWild(rr.name)) {
+        ret.push(rr);
+        continue;
+      }
+
+      const x = util.splitName(name);
+      const y = util.splitName(rr.name);
+
+      if (x.length < y.length)
+        continue;
+
+      // Remove '*' label and test remainder
+      y.shift();
+
+      let push = true;
+      for (let i = 1; i <= y.length; i++) {
+        if (y[y.length - i] !== x[x.length - i]) {
+          push = false;
+          break;
+        }
+      }
+      if (!push)
+        continue;
+
+      ret.push(rr);
+    }
+
+    return ret;
+  }
+
   push(name, type, an) {
     assert(util.isFQDN(name));
     assert((type & 0xffff) === type);
@@ -401,15 +435,17 @@ class RecordMap {
     // other records for that name in the zone.
     // (RFC 1034 section 3.6.2, RFC 1912 section 2.4)
     if (type !== types.CNAME) {
-      const rrs = this.rrs.get(types.CNAME);
+      let rrs = this.rrs.get(types.CNAME);
 
       if (rrs && rrs.length > 0) {
+        rrs = this.filterMatches(name, rrs);
         for (const rr of rrs)
           an.push(convert(name, rr));
 
-        const sigs = this.sigs.get(types.CNAME);
+        let sigs = this.sigs.get(types.CNAME);
 
         if (sigs) {
+          sigs = this.filterMatches(name, sigs);
           for (const rr of sigs)
             an.push(convert(name, rr));
         }
@@ -418,15 +454,17 @@ class RecordMap {
       }
     }
 
-    const rrs = this.rrs.get(type);
+    let rrs = this.rrs.get(type);
 
     if (rrs && rrs.length > 0) {
+      rrs = this.filterMatches(name, rrs);
       for (const rr of rrs)
         an.push(convert(name, rr));
 
-      const sigs = this.sigs.get(type);
+      let sigs = this.sigs.get(type);
 
       if (sigs) {
+        sigs = this.filterMatches(name, sigs);
         for (const rr of sigs)
           an.push(convert(name, rr));
       }
@@ -551,23 +589,9 @@ function convert(name, rr) {
   if (!isWild(rr.name))
     return rr;
 
-  const x = util.splitName(name);
-  const y = util.splitName(rr.name);
-
-  assert(y.length > 0);
-
-  if (x.length < y.length)
-    return rr;
-
   rr = rr.clone();
 
-  // Replace '*' with prefix, may be multiple labels
-  y.shift();
-  let diff = x.length - y.length - 1;
-  for (; diff >= 0; diff--)
-    y.unshift(x[diff]);
-
-  rr.name = `${y.join('.')}.`;
+  rr.name = name;
 
   return rr;
 }

--- a/test/zone-test.js
+++ b/test/zone-test.js
@@ -121,7 +121,7 @@ describe('Zone', function() {
 
     for (const t of Object.keys(types)) {
       it(`should serve CNAME + glue as answers for type: ${t}`, () => {
-        if (t === 'NS' || t === 'ANY')
+        if (t === 'NS' || t === 'ANY' || t === 'UNKNOWN' || t === 'SOA')
           this.skip(); // TODO
 
         const msg = zone.resolve(subdomainWithGlue, types[t]);
@@ -129,21 +129,25 @@ describe('Zone', function() {
         assert(!msg.aa);
         assert(msg.authority.length === 0);
         assert(msg.additional.length === 0);
-        assert(msg.answer.length === 2);
 
-        let cname = false;
-        let a = false;
-        for (const an of msg.answer) {
-          if (an.type === types.CNAME)
-            cname = true;
+        if (t !== 'A') {
+          assert(msg.answer.length === 1);
+          assert(msg.answer[0].type === types.CNAME);
+        } else {
+          let cname = false;
+          let a = false;
+          for (const an of msg.answer) {
+            if (an.type === types.CNAME)
+              cname = true;
 
-          if (an.type === types.A) {
-            a = true;
-            assert (an.data.address = '10.20.30.40');
+            if (an.type === types.A) {
+              a = true;
+              assert (an.data.address = '10.20.30.40');
+            }
           }
+          assert(cname);
+          assert(a);
         }
-        assert(cname);
-        assert(a);
       });
     }
 
@@ -180,7 +184,7 @@ describe('Zone', function() {
 
     for (const t of Object.keys(types)) {
       it(`should serve CNAME + glue as answers for type: ${t}`, () => {
-        if (t === 'NS' || t === 'ANY')
+        if (t === 'NS' || t === 'ANY' || t === 'UNKNOWN')
           this.skip(); // TODO
 
         const msg = zone.resolve(subdomainWithGlue, types[t]);
@@ -188,21 +192,25 @@ describe('Zone', function() {
         assert(!msg.aa);
         assert(msg.authority.length === 0);
         assert(msg.additional.length === 0);
-        assert(msg.answer.length === 2);
 
-        let cname = false;
-        let a = false;
-        for (const an of msg.answer) {
-          if (an.type === types.CNAME)
-            cname = true;
+        if (t !== 'A') {
+          assert(msg.answer.length === 1);
+          assert(msg.answer[0].type === types.CNAME);
+        } else {
+          let cname = false;
+          let a = false;
+          for (const an of msg.answer) {
+            if (an.type === types.CNAME)
+              cname = true;
 
-          if (an.type === types.A) {
-            a = true;
-            assert (an.data.address = '10.20.30.40');
+            if (an.type === types.A) {
+              a = true;
+              assert (an.data.address = '10.20.30.40');
+            }
           }
+          assert(cname);
+          assert(a);
         }
-        assert(cname);
-        assert(a);
       });
     }
   });

--- a/test/zone-test.js
+++ b/test/zone-test.js
@@ -52,4 +52,158 @@ describe('Zone', function() {
       assert.deepStrictEqual(msg.authority, expect);
     }
   });
+
+  describe('Serve records from zone', function() {
+    const zone = new Zone();
+    const domain = 'thebnszone.';
+    const subdomainWithGlue = 'subdomain-glue.' + domain;
+    const subdomainNoGlue = 'subdomain-external.' + domain;
+    const subdomainWithText = 'subdomain-text.' + domain;
+
+    // TLD
+    zone.setOrigin(domain);
+    // A record for TLD (Common in Handshake, not in DNS)
+    zone.fromString(`${domain} 21600 IN A 10.20.30.40`);
+    // TXT record for TLD
+    zone.fromString(`${subdomainWithText} 21600 IN TXT "subdomain-with-text"`);
+    // TXT for wildcard
+    zone.fromString('* 21600 IN TXT "wildcard"');
+    // CNAME for subdomain -> TLD
+    zone.fromString(`${subdomainWithGlue} 21600 IN CNAME ${domain}`);
+    // CNAME for subdomain -> other zone
+    zone.fromString(`${subdomainNoGlue} 21600 IN CNAME idontexist.`);
+    // SOA to trigger authority flag
+    zone.fromString(
+      `${domain} 21600 IN SOA ns1.${domain} admin.${domain} ` +
+      '2020070500 86400 7200 604800 300'
+    );
+
+    it('should serve A record', () => {
+      const msg = zone.resolve(domain, types.A);
+      assert(msg.code === codes.NOERROR);
+      assert(msg.aa);
+      assert(msg.authority.length === 0);
+      assert(msg.additional.length === 0);
+      assert(msg.answer.length === 1);
+      assert(msg.answer[0].data.address = '10.20.30.40');
+    });
+
+    it('should serve SOA record for missing type', () => {
+      const msg = zone.resolve(domain, types.AAAA);
+      assert(msg.code === codes.NOERROR);
+      assert(msg.aa);
+      assert(msg.authority.length === 1);
+      assert(msg.additional.length === 0);
+      assert(msg.answer.length === 0);
+    });
+
+    it('should serve TXT record for wildcard', () => {
+      const msg = zone.resolve(`idontexist.${domain}`, types.TXT);
+      assert(msg.code === codes.NOERROR);
+      assert(!msg.aa);
+      assert(msg.authority.length === 0);
+      assert(msg.additional.length === 0);
+      assert(msg.answer.length === 1);
+      assert(msg.answer[0].data.txt.length === 1);
+      assert(msg.answer[0].data.txt[0] === 'wildcard' );
+    });
+
+    it('should serve TXT record for defined subdomain', () => {
+      const msg = zone.resolve(`${subdomainWithText}`, types.TXT);
+      assert(msg.code === codes.NOERROR);
+      assert(!msg.aa);
+      assert(msg.authority.length === 0);
+      assert(msg.additional.length === 0);
+      assert(msg.answer.length === 1);
+      assert(msg.answer[0].data.txt.length === 1);
+      assert(msg.answer[0].data.txt[0] === 'subdomain-with-text');
+    });
+
+    for (const t of Object.keys(types)) {
+      it(`should serve CNAME + glue as answers for type: ${t}`, () => {
+        if (t === 'NS' || t === 'ANY')
+          this.skip(); // TODO
+
+        const msg = zone.resolve(subdomainWithGlue, types[t]);
+        assert(msg.code === codes.NOERROR);
+        assert(!msg.aa);
+        assert(msg.authority.length === 0);
+        assert(msg.additional.length === 0);
+        assert(msg.answer.length === 2);
+
+        let cname = false;
+        let a = false;
+        for (const an of msg.answer) {
+          if (an.type === types.CNAME)
+            cname = true;
+
+          if (an.type === types.A) {
+            a = true;
+            assert (an.data.address = '10.20.30.40');
+          }
+        }
+        assert(cname);
+        assert(a);
+      });
+    }
+
+    for (const t of Object.keys(types)) {
+      it(`should serve CNAME only for type: ${t}`, () => {
+        if (t === 'NS' || t === 'ANY')
+          this.skip(); // TODO
+
+        const msg = zone.resolve(subdomainNoGlue, types[t]);
+        assert(msg.code === codes.NOERROR);
+        assert(!msg.aa);
+        assert(msg.authority.length === 0);
+        assert(msg.additional.length === 0);
+        assert(msg.answer.length === 1);
+        assert(msg.answer[0].type = types.CNAME);
+        assert(msg.answer[0].data.target = 'idontexist.');
+      });
+    }
+  });
+
+  describe('CNAME for wildcard', function() {
+    const zone = new Zone();
+    const domain = 'thebnszone.';
+    const subdomainWithGlue = 'subdomain-glue.' + domain;
+
+    // TLD
+    zone.setOrigin(domain);
+    // Reset zone.
+    zone.clearRecords();
+    // A record for TLD (Common in Handshake, not in DNS)
+    zone.fromString(`${domain} 21600 IN A 10.20.30.40`);
+    // CNAME for wildcard -> TXT
+    zone.fromString(`* 21600 IN CNAME ${domain}`);
+
+    for (const t of Object.keys(types)) {
+      it(`should serve CNAME + glue as answers for type: ${t}`, () => {
+        if (t === 'NS' || t === 'ANY')
+          this.skip(); // TODO
+
+        const msg = zone.resolve(subdomainWithGlue, types[t]);
+        assert(msg.code === codes.NOERROR);
+        assert(!msg.aa);
+        assert(msg.authority.length === 0);
+        assert(msg.additional.length === 0);
+        assert(msg.answer.length === 2);
+
+        let cname = false;
+        let a = false;
+        for (const an of msg.answer) {
+          if (an.type === types.CNAME)
+            cname = true;
+
+          if (an.type === types.A) {
+            a = true;
+            assert (an.data.address = '10.20.30.40');
+          }
+        }
+        assert(cname);
+        assert(a);
+      });
+    }
+  });
 });


### PR DESCRIPTION
Closes #5 , #21, #16, #15 

A few edge cases aren't complete, indicated by `skip` in some of the tests.
Test cases were designed to match results from adding the same record set to `named` and querying.

Changes summary:

### zone: only serve wildcard if there was otherwise no match

if `*.domain.` exists in the zone along with `sub.domain.`, do not return the wildcard record as an answer for `domain.` or `sub.domain` or `sub.otherdomain.`

### zone: return CNAME records for any type requested

```
sub.domain. CNAME domain.
```

We should return this CNAME record whenever `sub.domain` is requested, no matter what the requested type is.

### zone: glue requested type, default A / AAAA

Assuming "glue" exists:

```
sub.domain. CNAME domain.
domain. TXT "return this string"
domain. A 10.20.30.40
```

When `sub.domain.` is queried, the corresponding type should be returned as "glue" (it goes in the answer section though, not additional). We return A/AAAA records by default. In other words, the CNAME glue is treated like its own request, including adding SOA to authority section if no answer is available. So `sub.domain. TXT` would return the CNAME record along with the TXT record.

### zone: wildcard matches more than one label

```
*.domain. TXT "wow such zone file"
```

This record should be matched against `sub.domain. TXT` but also `foo.bar.sub.domain. TXT`.

### zone: filter out wildcards that do not match

```
*.domain. TXT "wow such zone file"
```

This record should NOT be returned for a query for `another.domain.` because it does not match.

### zone: add SOA if authoritative but no answers. Applies to CNAME glue

Always sets the `aa` flag if we have a corresponding SOA in the zone, even if we don't include an actual SOA record (which we usually don't if an answer is present). This will also apply to "glue" from CNAME matches:

(results from `named`)

#### Record matching requested type present for target of CNAME:

```
$ dig @127.0.0.1 -p 5300 subdomain-glue.coolness. a

; <<>> DiG 9.16.3 <<>> @127.0.0.1 -p 5300 subdomain-glue.coolness. a
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 22759
;; flags: qr aa rd; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
; COOKIE: 49555c2cbce32a34010000005f04854da468d429742abd77 (good)
;; QUESTION SECTION:
;subdomain-glue.coolness.       IN      A

;; ANSWER SECTION:
subdomain-glue.coolness. 21600  IN      CNAME   coolness.
coolness.               21600   IN      A       10.20.30.40

;; Query time: 0 msec
;; SERVER: 127.0.0.1#5300(127.0.0.1)
;; WHEN: Tue Jul 07 10:23:09 EDT 2020
;; MSG SIZE  rcvd: 110
```

#### Record matching requested type NOT present for target of CNAME:

```
$ dig @127.0.0.1 -p 5300 subdomain-glue.coolness. dnskey

; <<>> DiG 9.16.3 <<>> @127.0.0.1 -p 5300 subdomain-glue.coolness. dnskey
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 39596
;; flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 1, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
; COOKIE: 0881e1c766abc5dc010000005f04855092e02236a58a19af (good)
;; QUESTION SECTION:
;subdomain-glue.coolness.       IN      DNSKEY

;; ANSWER SECTION:
subdomain-glue.coolness. 21600  IN      CNAME   coolness.

;; AUTHORITY SECTION:
coolness.               300     IN      SOA     ns1.dns.live. root.coolness. 2020061644 21600 3600 2419200 86400

;; Query time: 0 msec
;; SERVER: 127.0.0.1#5300(127.0.0.1)
;; WHEN: Tue Jul 07 10:23:12 EDT 2020
;; MSG SIZE  rcvd: 147
```


