### PR TITLE
Improve ipv6 support

### DIFF
--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -13,7 +13,7 @@ const tcp = require('btcp');
 const udp = require('budp');
 const bio = require('bufio');
 const util = require('../util');
-const hasIPv6 = IP.getPublic('ipv6').length > 0;
+const hasIPv6 = IP.getInterfaces('ipv6').length > 0;
 
 /**
  * Base

--- a/lib/resolver/ub.js
+++ b/lib/resolver/ub.js
@@ -44,7 +44,7 @@ class UnboundResolver extends EventEmitter {
   constructor(options) {
     super();
 
-    this.inet6 = false;
+    this.inet6 = IP.getInterfaces('ipv6').length > 0;;
     this.tcp = false;
     this.forceTCP = false;
     this.maxAttempts = 3;

--- a/lib/resolver/ub.js
+++ b/lib/resolver/ub.js
@@ -141,6 +141,11 @@ class UnboundResolver extends EventEmitter {
       this.minimize = options.minimize;
     }
 
+    if (options.inet6 != null) {
+      assert(typeof options.inet6 === 'boolean');
+      this.inet6 = options.inet6;
+    }
+
     return this;
   }
 


### PR DESCRIPTION
This will be connected with a PR to hsd to fix some lingering issues with ipv6.

1) We used to only allow ipv6 by default if we detected public ipv6 addresses in the OS's interfaces. This prevented binding to `::1` locally

2) The `inet6` option was not being parsed in the Unbound resolver, leaving it always as `false`