### PR TITLE
resolver: handle different zone signer

### DIFF
--- a/lib/resolver/recursive.js
+++ b/lib/resolver/recursive.js
@@ -123,6 +123,11 @@ class RecursiveResolver extends DNSResolver {
     return this.hints.getAuthority(this.inet6);
   }
 
+  /**
+   * @param {wire.Question} qs
+   * @param {Authority} auth
+   * @returns {Promise<[wire.Message, boolean]>}
+   */
   async ask(qs, auth) {
     const cache = this.cache.hit(qs, auth.zone);
 
@@ -354,6 +359,62 @@ class RecursiveResolver extends DNSResolver {
     }
   }
 
+  /**
+   * A single nameserver may host multiple zones.
+   * When an RRSIG does not match the current zone,
+   * we switch zones first before handling trust.
+   * @param {ResolveContext} rc
+   */
+  async handleDifferentRRSIGZone(rc) {
+    if (!rc.res.isAnswer())
+      return;
+
+    const rrsigs = extractSet(rc.res.answer, '', types.RRSIG);
+    if (rrsigs.length === 0)
+      return;
+
+    const signerNames = new Set(rrsigs.map(rrsig => rrsig.data.signerName));
+    if (signerNames.has(rc.auth.zone))
+      return;
+
+    // There is a zone cut,
+    // this is the zone we switch to
+    const [signerName] = signerNames;
+
+    // Get the NS and DS for new zone
+    const [nsRes] = await this.ask(new Question(signerName, types.NS), rc.auth);
+    if (!nsRes.isAnswer()) {
+      this.log('Trust chain broken due to lack of NS record.');
+      return;
+    }
+    const [dsRes] = await this.ask(new Question(signerName, types.DS), rc.auth);
+    if (!dsRes.isAnswer()) {
+      this.log('Trust chain broken due to lack of DS record.');
+      return;
+    }
+
+    // Switch authority/zone
+    const auth = await this.pickAuthority(rc, nsRes.answer, nsRes.additional);
+    this.insert(rc);
+
+    if (!auth)
+      return;
+
+    this.log('Switching authority: %s', auth.name);
+    this.log('Switching zone: [%s->%s]', rc.auth.zone, auth.zone);
+
+    // Grab DS records for the _next_ zone.
+    rc.ds = extractSet(dsRes.answer, auth.zone, types.DS);
+
+    if (rc.ds.length === 0) {
+      rc.chain = false;
+      this.log('Trust chain broken due to zone change.');
+    }
+
+    rc.switchZone(auth);
+    rc.hop();
+  }
+
   async handleTrust(rc) {
     assert(rc.chain);
 
@@ -485,8 +546,10 @@ class RecursiveResolver extends DNSResolver {
   async next(rc) {
     await this.lookupNext(rc);
 
-    if (rc.chain)
+    if (rc.chain) {
+      await this.handleDifferentRRSIGZone(rc);
       await this.handleTrust(rc);
+    }
 
     if (rc.chain && rc.res.code === codes.NXDOMAIN) {
       const nsec = extractSet(rc.res.authority, '', types.NSEC3);


### PR DESCRIPTION
Closes #26.

When nameservers host both a parent and child zone, bns doesn't realize the zone cut and doesn't verify signatures correctly, leading to an **Invalid RRSIGs** error.

This PR identifies such cases by comparing RRSIGs (as suggested [here](https://github.com/chjj/bns/issues/26#issuecomment-1478853448), thanks @buffrr) and switching to that zone before verifying any answer.

The original domain in the issue `sebastian.rasor` no longer has a signed zone, so these 2 examples can be used to review/test: `e.xp`, `henry.kelder`

The tests haven't been updated in a long time and will likely fail just like the main branch, but I've compared it to the (almost) fixed tests from https://github.com/chjj/bns/pull/36 and no _extra_ cases fail. Of course, this still needs proper review.

shameless plug of sitecheck to help visualize these dnssec chains: https://sitecheck.htools.work/check/e.xp / https://sitecheck.htools.work/check/henry.kelder

<details>
  <summary>dig.js output for e.xp</summary>

```
❯ ./bin/dig.js --recursive e.xp +dnssec +debug @127.0.0.1 -p 5349 --anchor '. DS 35215 13 2 7C50EA94A63AEECB65B510D1EAC1846C973A89D4AB292287D5A4D715136B57A3'

Querying e.xp. (A).
Switching authority: hints.local.
Switching zone: [.]
Querying server: 127.0.0.1 (19235) (tcp=false)
Verifying zone change to [.]
Checking signatures...
Querying server: 127.0.0.1 (59457) (tcp=false)
Validated DNSSEC signatures.
Looking up NS: ns2.hshub.
Looking up IPv4 nameserver for ns2.hshub....
Querying ns2.hshub. (A).
Switching authority: hints.local.
Switching zone: [.]
Querying server: 127.0.0.1 (22090) (tcp=false)
Verifying zone change to [.]
Checking signatures...
Cache hit for . (DNSKEY).
Validated DNSSEC signatures.
Switching authority: ns2.hshub.
Switching zone: [.->hshub.]
Querying server: 192.198.87.44 (37739) (tcp=false)
Verifying zone change to [hshub.]
Checking signatures...
Querying server: 135.148.148.132 (52205) (tcp=false)
Validated DNSSEC signatures.
Traversed zones: ., hshub. for ns2.hshub. (A).
Picked nameserver for: ns2.hshub.
Switching authority: ns2.hshub.
Switching zone: [.->xp.]
Querying server: 135.148.148.132 (4281) (tcp=false)
Querying server: 135.148.148.132 (2921) (tcp=false)
Querying server: 135.148.148.132 (8602) (tcp=false)
Looking up NS: ns1.varo.
Looking up IPv4 nameserver for ns1.varo....
Querying ns1.varo. (A).
Switching authority: hints.local.
Switching zone: [.]
Querying server: 127.0.0.1 (5147) (tcp=false)
Verifying zone change to [.]
Checking signatures...
Cache hit for . (DNSKEY).
Validated DNSSEC signatures.
Switching authority: ns1.varo.
Switching zone: [.->varo.]
Querying server: 135.148.148.132 (1294) (tcp=false)
Verifying zone change to [varo.]
Checking signatures...
Querying server: 192.198.87.44 (41026) (tcp=false)
Validated DNSSEC signatures.
Traversed zones: ., varo. for ns1.varo. (A).
Picked nameserver for: ns1.varo.
Switching authority: ns1.varo.
Switching zone: [xp.->e.xp.]
Verifying zone change to [e.xp.]
Checking signatures...
Querying server: 192.198.87.44 (44204) (tcp=false)
Validated DNSSEC signatures.
Traversed zones: ., xp., e.xp. for e.xp. (A).
Finishing resolving e.xp. (A) (hops=6).
Cache usage: 0.00/5.00mb (items=11).

; <<>> dig.js 0.15.0 <<>> --recursive e.xp +dnssec +debug @127.0.0.1 -p 5349 --anchor . DS 35215 13 2 7C50EA94A63AEECB65B510D1EAC1846C973A89D4AB292287D5A4D715136B57A3
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 4281
;; flags: qr rd ra ad; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags: do; udp: 1232
;; QUESTION SECTION:
;e.xp. IN A

;; ANSWER SECTION:
e.xp. 20 IN A 74.91.123.138
e.xp. 20 IN RRSIG A 13 2 20 20230406000000 20230316000000 46984 e.xp. 6ojTy79GeHsZeKQbXCzArhbvE+YTiZrg7FcC+iPcaryozKR92W429hnU 6yNyfzmQh6vCKUGNNJzPT3fnlPCzaA==  ; alg = ECDSAP256SHA256

;; Query time: 2027 msec
;; SERVER: 127.0.0.1#5349(127.0.0.1)
;; WHEN: Fri Mar 24 16:19:01 IST 2023
;; MSG SIZE  rcvd: 149
```
</details>

<details>
  <summary>dig.js output for henry.kelder</summary>

```
❯ ./bin/dig.js --recursive henry.kelder +dnssec +debug @127.0.0.1 -p 5349 --anchor '. DS 35215 13 2 7C50EA94A63AEECB65B510D1EAC1846C973A89D4AB292287D5A4D715136B57A3'

Querying henry.kelder. (A).
Switching authority: hints.local.
Switching zone: [.]
Querying server: 127.0.0.1 (14689) (tcp=false)
Verifying zone change to [.]
Checking signatures...
Querying server: 127.0.0.1 (22194) (tcp=false)
Validated DNSSEC signatures.
Switching authority: ns1.kelder.
Switching zone: [.->kelder.]
Querying server: 34.123.215.203 (50838) (tcp=false)
Querying server: 34.123.215.203 (64888) (tcp=false)
Querying server: 34.123.215.203 (19480) (tcp=false)
Looking up NS: ns.superlink.me.
Looking up IPv4 nameserver for ns.superlink.me....
Querying ns.superlink.me. (A).
Switching authority: hints.local.
Switching zone: [.]
Querying server: 127.0.0.1 (59675) (tcp=false)
Verifying zone change to [.]
Checking signatures...
Cache hit for . (DNSKEY).
Validated DNSSEC signatures.
Switching authority: a0.nic.me.
Switching zone: [.->me.]
Querying server: 199.249.119.1 (857) (tcp=false)
Verifying zone change to [me.]
Checking signatures...
Querying server: 199.249.127.1 (48924) (tcp=false)
Validated DNSSEC signatures.
Looking up NS: ns-cloud-d4.googledomains.com.
Looking up IPv4 nameserver for ns-cloud-d4.googledomains.com....
Querying ns-cloud-d4.googledomains.com. (A).
Switching authority: hints.local.
Switching zone: [.]
Querying server: 127.0.0.1 (54942) (tcp=false)
Verifying zone change to [.]
Checking signatures...
Cache hit for . (DNSKEY).
Validated DNSSEC signatures.
Switching authority: c.gtld-servers.net.
Switching zone: [.->com.]
Querying server: 192.31.80.30 (275) (tcp=false)
Verifying zone change to [com.]
Checking signatures...
Querying server: 192.55.83.30 (36318) (tcp=false)
Validated DNSSEC signatures.
Validated NSEC3 delegation.
Switching authority: ns5.googledomains.com.
Switching zone: [com.->googledomains.com.]
Trust chain broken due to zone change.
Querying server: 216.239.36.10 (21293) (tcp=false)
Traversed zones: ., com., googledomains.com. for ns-cloud-d4.googledomains.com. (A).
Picked nameserver for: ns-cloud-d4.googledomains.com.
Validated NSEC3 delegation.
Switching authority: ns-cloud-d4.googledomains.com.
Switching zone: [me.->superlink.me.]
Trust chain broken due to zone change.
Querying server: 216.239.38.109 (52235) (tcp=false)
Traversed zones: ., me., superlink.me. for ns.superlink.me. (A).
Picked nameserver for: ns.superlink.me.
Switching authority: ns.superlink.me.
Switching zone: [kelder.->henry.kelder.]
Verifying zone change to [henry.kelder.]
Checking signatures...
Querying server: 34.123.215.203 (49788) (tcp=false)
Validated DNSSEC signatures.
Traversed zones: ., kelder., henry.kelder. for henry.kelder. (A).
Finishing resolving henry.kelder. (A) (hops=8).
Cache usage: 0.01/5.00mb (items=13).

; <<>> dig.js 0.15.0 <<>> --recursive henry.kelder +dnssec +debug @127.0.0.1 -p 5349 --anchor . DS 35215 13 2 7C50EA94A63AEECB65B510D1EAC1846C973A89D4AB292287D5A4D715136B57A3
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 50838
;; flags: qr rd ra ad; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags: do; udp: 1232
;; QUESTION SECTION:
;henry.kelder. IN A

;; ANSWER SECTION:
henry.kelder. 3600 IN RRSIG A 13 2 3600 20230406000000 20230316000000 61307 henry.kelder. p7J2MNceSPaHyxbNItPz5qFXg4uI1T0hj8b/j4XtruSF8R9UQTKEV6P3 7zL8GIEllM47lmJuJpYxMrlY4JDfiQ==  ; alg = ECDSAP256SHA256
henry.kelder. 3600 IN A 34.136.25.237

;; Query time: 1798 msec
;; SERVER: 127.0.0.1#5349(127.0.0.1)
;; WHEN: Fri Mar 24 16:21:04 IST 2023
;; MSG SIZE  rcvd: 165

```
</details>