### PR TITLE
rs: do not strip authority section in response

### DIFF
--- a/lib/server/dns.js
+++ b/lib/server/dns.js
@@ -194,7 +194,6 @@ class DNSServer extends EventEmitter {
 
     if (this.ra) {
       if (res.answer.length > 0) {
-        res.authority = [];
         res.additional = [];
       }
 


### PR DESCRIPTION
(similar to https://github.com/handshake-org/hnsd/pull/126)


Recursive resolvers should return the NSEC record in the AUTHORITY section for successful verification of wildcard records.  Trying to do so right now (in both hsd and hnsd) fail with `noqname proof not found`.

more info: https://datatracker.ietf.org/doc/html/rfc5155#section-8.8

### Live example

`*.home.htools` is a wildcard TLSA record in zone `htools` at 129.153.177.220.

Start hsd with (`--rs-no-unbound` can be true or false, both have the same issue):
```sh
hsd --no-sig0 --rs-no-unbound true --log-level spam
```

Without this PR:
```
❯ delv @127.0.0.1 -p 5350 -a ~/.hsd-ksk _443._tcp.home.htools TLSA +rtrace +vtrace +nosplit
;; fetch: _443._tcp.home.htools/TLSA
;; validating _443._tcp.home.htools/TLSA: starting
;; validating _443._tcp.home.htools/TLSA: attempting positive response validation
;; fetch: htools/DNSKEY
;; validating htools/DNSKEY: starting
;; validating htools/DNSKEY: attempting positive response validation
;; fetch: htools/DS
;; validating htools/DS: starting
;; validating htools/DS: attempting positive response validation
;; fetch: ./DNSKEY
;; validating ./DNSKEY: starting
;; validating ./DNSKEY: attempting positive response validation
;; validating ./DNSKEY: verify rdataset (keyid=35215): success
;; validating ./DNSKEY: marking as secure (DS)
;; validating htools/DS: in fetch_callback_dnskey
;; validating htools/DS: keyset with trust secure
;; validating htools/DS: resuming validate
;; validating htools/DS: verify rdataset (keyid=60944): success
;; validating htools/DS: marking as secure, noqname proof not needed
;; validating htools/DNSKEY: in fetch_callback_ds
;; validating htools/DNSKEY: dsset with trust secure
;; validating htools/DNSKEY: verify rdataset (keyid=24809): success
;; validating htools/DNSKEY: marking as secure (DS)
;; validating _443._tcp.home.htools/TLSA: in fetch_callback_dnskey
;; validating _443._tcp.home.htools/TLSA: keyset with trust secure
;; validating _443._tcp.home.htools/TLSA: resuming validate
;; validating _443._tcp.home.htools/TLSA: verify rdataset (keyid=24809): from wildcard
;; validating _443._tcp.home.htools/TLSA: looking for noqname proof
;; validating _443._tcp.home.htools/TLSA: noqname proof not found
;; no valid NSEC resolving '_443._tcp.home.htools/TLSA/IN': 127.0.0.1#5350
;; resolution failed: no valid NSEC
```

With this PR:
```
❯ delv @127.0.0.1 -p 5350 -a ~/.hsd-ksk _443._tcp.home.htools TLSA +rtrace +vtrace +nosplit
;; fetch: _443._tcp.home.htools/TLSA
;; validating _443._tcp.home.htools/TLSA: starting
;; validating _443._tcp.home.htools/TLSA: attempting positive response validation
;; fetch: htools/DNSKEY
;; validating htools/DNSKEY: starting
;; validating htools/DNSKEY: attempting positive response validation
;; fetch: htools/DS
;; validating htools/DS: starting
;; validating htools/DS: attempting positive response validation
;; fetch: ./DNSKEY
;; validating ./DNSKEY: starting
;; validating ./DNSKEY: attempting positive response validation
;; validating ./DNSKEY: verify rdataset (keyid=35215): success
;; validating ./DNSKEY: marking as secure (DS)
;; validating htools/DS: in fetch_callback_dnskey
;; validating htools/DS: keyset with trust secure
;; validating htools/DS: resuming validate
;; validating htools/DS: verify rdataset (keyid=60944): success
;; validating htools/DS: marking as secure, noqname proof not needed
;; validating htools/DNSKEY: in fetch_callback_ds
;; validating htools/DNSKEY: dsset with trust secure
;; validating htools/DNSKEY: verify rdataset (keyid=24809): success
;; validating htools/DNSKEY: marking as secure (DS)
;; validating _443._tcp.home.htools/TLSA: in fetch_callback_dnskey
;; validating _443._tcp.home.htools/TLSA: keyset with trust secure
;; validating _443._tcp.home.htools/TLSA: resuming validate
;; validating _443._tcp.home.htools/TLSA: verify rdataset (keyid=24809): from wildcard
;; validating _443._tcp.home.htools/TLSA: looking for noqname proof
;;   validating _atproto.home.htools/NSEC: starting
;;   validating _atproto.home.htools/NSEC: attempting positive response validation
;;   validating _atproto.home.htools/NSEC: keyset with trust secure
;;   validating _atproto.home.htools/NSEC: verify rdataset (keyid=24809): success
;;   validating _atproto.home.htools/NSEC: marking as secure, noqname proof not needed
;; validating _443._tcp.home.htools/TLSA: in validator_callback_nsec
;; validating _443._tcp.home.htools/TLSA: looking for relevant NSEC
;; validating _443._tcp.home.htools/TLSA: nsec range ok
;; validating _443._tcp.home.htools/TLSA: resuming validate_nx
;; validating _443._tcp.home.htools/TLSA: marking as secure, noqname proof found
; fully validated
_443._tcp.home.htools.  299     IN      TLSA    3 1 1 EFB386BDFB86E2249988443E79123773662CE0F4530BAC08732FFF4E5489262F
_443._tcp.home.htools.  299     IN      RRSIG   TLSA 13 2 3600 20240321000000 20240229000000 24809 htools. ErdmlQd93r4FGz3xdABOMqZY7W3kBfHF5ge2LsgtaJQBR2/cVneV+6iTw5ZmQIAJtz7QLHxE6N9ieddKilshMQ==
```